### PR TITLE
refactor: Remove redundant CSS mock folder

### DIFF
--- a/visual_dashboard/__mocks__/styleMock.js
+++ b/visual_dashboard/__mocks__/styleMock.js
@@ -1,1 +1,0 @@
-module.exports = {};


### PR DESCRIPTION
## 🧹 Cleanup: Remove Redundant CSS Mock Folder

### Problem
The `visual_dashboard/__mocks__/` folder contains a `styleMock.js` file that is redundant because CSS mocking is already properly handled in the Vitest setup.

### Solution
- **Removed** `visual_dashboard/__mocks__/styleMock.js`
- **Eliminated** the entire `__mocks__` directory

### Why This Change?
1. **Duplicate Functionality**: CSS mocking is already handled in `__tests__/setup.ts` using `vi.mock()`
2. **Modern Approach**: Vitest configuration properly handles CSS imports without requiring external mock files
3. **Cleaner Structure**: Reduces project complexity by eliminating duplicate mocking approaches
4. **Consistency**: Uses a single, consistent approach for CSS mocking directly in test setup

### Technical Details
- The project uses **Tailwind CSS** which doesn't require CSS module mocking
- **Next.js 15** handles CSS imports automatically
- **Vitest** configuration already includes proper CSS handling via `vi.mock()` in setup.ts

### Verification
✅ CSS mocking is still functional through `__tests__/setup.ts`  
✅ Tests should continue to pass without the redundant mock folder  
✅ Project structure is cleaner and more maintainable  

### Files Changed
- `visual_dashboard/__mocks__/styleMock.js` - **Removed**